### PR TITLE
Fix typo — clang 10.0 to clang 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## [Unreleased]
-- 
+-
+
+## 1.0.3 - 2021.09.02
+- Fix typo with clang-10 install 
 
 ## 1.0.2 - 2021.08.29
 ### Changed

--- a/vagrantfile
+++ b/vagrantfile
@@ -18,10 +18,10 @@ Vagrant.configure(2) do |config|
         sudo apt-get -y upgrade
         sudo apt-get install -y virtualbox-guest-utils
         sudo apt-get install -y emacs
-        sudo apt-get install -y clang-10.0
+        sudo apt-get install -y clang-10
         sudo apt-get install -y clang-format-10
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10.0 100
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
         sudo apt-get install -y gdb
         sudo apt-get install -y lldb-3.8
         sudo apt-get install -y valgrind


### PR DESCRIPTION
Per https://piazza.com/class/krtmu8tans12en?cid=76 there is a typo in the new Vagrantfile that doesn't properly install clang on some environments. 

I have not tested this Vagrantfile yet though. If anyone has time to do this before merge that would be great. 